### PR TITLE
Use Delay

### DIFF
--- a/omegler.js
+++ b/omegler.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
         $(".chatmsg", document).html(msg);
         if ($(".sendbtn", document).is(":disabled")) {
             return setTimeout(function () {
-                write(msg);
+                write(msg, delay);
             }, 200);
         }
         stopper = 0;


### PR DESCRIPTION
When the send button is disabled, it currently recurses back to itself after 200ms... but just doesn't include the delay, leaving the delay to simply not register most times.